### PR TITLE
feat: RespawnCommandの追加

### DIFF
--- a/src/main/java/net/azisaba/afnw/afnwcore2/AfnwCore2.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/AfnwCore2.java
@@ -1,6 +1,7 @@
 package net.azisaba.afnw.afnwcore2;
 
 import net.azisaba.afnw.afnwcore2.commands.AfnwCommand;
+import net.azisaba.afnw.afnwcore2.commands.RespawnCommand;
 import net.azisaba.afnw.afnwcore2.commands.VoteCommand;
 import net.azisaba.afnw.afnwcore2.listeners.player.FirstPlayerJoinListener;
 import net.azisaba.afnw.afnwcore2.listeners.player.JoinListener;
@@ -33,6 +34,7 @@ public class AfnwCore2 extends JavaPlugin {
         // register commands
         Objects.requireNonNull(getCommand("afnw")).setExecutor(new AfnwCommand(this));
         Objects.requireNonNull(getCommand("vote")).setExecutor(new VoteCommand());
+        Objects.requireNonNull(getCommand("respawn")).setExecutor(new RespawnCommand());
 
         getLogger().info("[AfnwCore2] Enabled!");
     }

--- a/src/main/java/net/azisaba/afnw/afnwcore2/commands/AfnwCommand.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/commands/AfnwCommand.java
@@ -29,9 +29,14 @@ public record AfnwCommand(JavaPlugin plugin) implements CommandExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (!(command.getName().equals("afnw"))) return true;
+        if (!(command.getName().equals("afnw"))) {
+            return true;
+        }
         if (!(sender instanceof Player)) {
             sender.sendMessage(Component.text("/afnwコマンドはプレイヤーのみ実行可能です。").color(NamedTextColor.RED));
+            return true;
+        }
+        if(!(sender.hasPermission("afnw.command.afnw"))) {
             return true;
         }
 

--- a/src/main/java/net/azisaba/afnw/afnwcore2/commands/RespawnCommand.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/commands/RespawnCommand.java
@@ -1,0 +1,56 @@
+package net.azisaba.afnw.afnwcore2.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RespawnCommand implements TabExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if(!(command.getName().equals("respawn"))) {
+            return true;
+        }
+        if(args.length == 0) {
+            sender.sendMessage(Component.text("Usage: /respawn <player>", NamedTextColor.RED));
+            return true;
+        }
+
+        Player target = Bukkit.getPlayer(args[0]);
+        if(target == null) {
+            sender.sendMessage(Component.text("プレイヤーを見つけることができませんでした。", NamedTextColor.RED));
+            return true;
+        }
+
+        target.spigot().respawn();
+        sender.sendMessage(Component.text(target.getName() + "を強制的にリスポーンさせました。", NamedTextColor.YELLOW));
+
+        return true;
+    }
+
+    private static @NotNull List<String> filter(Stream<String> stream, String s) {
+        return stream.filter(s1 -> s1.toLowerCase(Locale.ROOT).startsWith(s.toLowerCase(Locale.ROOT))).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if(args.length == 0) {
+            return Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+        }
+        if(args.length == 1) {
+            return filter(Bukkit.getOnlinePlayers().stream().map(Player::getName), args[0]);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/azisaba/afnw/afnwcore2/commands/VoteCommand.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/commands/VoteCommand.java
@@ -13,7 +13,12 @@ public class VoteCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if(!(command.getName().equals("vote"))) return true;
+        if(!(command.getName().equals("vote"))) {
+            return true;
+        }
+        if(!(sender.hasPermission("afnw.command.vote"))) {
+            return true;
+        }
 
         String[] voteSiteURLs = {
                 ChatColor.GOLD +

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,9 +15,18 @@ permissions:
     default: op
   afnw.bypass.break.sapling:
     default: op
+  afnw.command.afnw:
+    default: false
+  afnw.command.vote:
+    default: false
+  afnw.command.respawn:
+    default: false
 
 commands:
   afnw:
     description: チケットとアイテムを交換します。
   vote:
     description: 投票サイト一覧を表示します。
+  respawn:
+    description: プレイヤーを強制的にリスポーンさせます。
+    usage: /respawn <player>


### PR DESCRIPTION
指定したプレイヤーを強制的にリスポーンさせるコマンドの追加

- [x] /respawn <player> の処理
- [x] TabにプレイヤーのIDリストを設定 (Tab補完できるように)

----

`/afnw`, `/vote` へのパーミッション追加も含んでいます。