### PR TITLE
chore: bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'net.azisaba.afnw'
-version = '0.1.0-beta'
+version = '0.2.0-beta'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
`v0.1.0-beta` -> `v0.2.0-beta`