### PR TITLE
feat: ネザーリスポーン機能の追加

### DIFF
--- a/src/main/java/net/azisaba/afnw/afnwcore2/AfnwCore2.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/AfnwCore2.java
@@ -20,6 +20,7 @@ import net.azisaba.afnw.afnwcore2.listeners.player.DeathListener;
 import net.azisaba.afnw.afnwcore2.listeners.player.FirstPlayerJoinListener;
 import net.azisaba.afnw.afnwcore2.listeners.player.JoinListener;
 import net.azisaba.afnw.afnwcore2.listeners.player.QuitListener;
+import net.azisaba.afnw.afnwcore2.listeners.player.RespawnNether;
 import net.azisaba.afnw.afnwcore2.util.data.PlayerData;
 import net.azisaba.afnw.afnwcore2.util.data.PlayerDataSave;
 import org.bukkit.Bukkit;
@@ -61,6 +62,7 @@ public class AfnwCore2 extends JavaPlugin {
     pluginEvent.registerEvents(new DeathListener(), this);
     pluginEvent.registerEvents(new FirstPlayerJoinListener(this, data), this);
     pluginEvent.registerEvents(new AFKListener(this), this);
+    pluginEvent.registerEvents(new RespawnNether(this), this);
     /* エンティティリスナー */
     pluginEvent.registerEvents(new WitherSpawn(this), this);
     getLogger().info("Listener 設定完了");

--- a/src/main/java/net/azisaba/afnw/afnwcore2/listeners/player/RespawnNether.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/listeners/player/RespawnNether.java
@@ -1,0 +1,37 @@
+package net.azisaba.afnw.afnwcore2.listeners.player;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.World.Environment;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public record RespawnNether(JavaPlugin plugin) implements Listener {
+
+  @EventHandler
+  public void onRespawn(PlayerRespawnEvent e) {
+    Player p = e.getPlayer();
+    if(e.getRespawnLocation().getWorld().getEnvironment() != Environment.NETHER) {
+      return;
+    }
+
+    Location respawn = p.getBedSpawnLocation();
+
+    if(respawn == null) {
+      FileConfiguration config = plugin.getConfig();
+      World lobby = Bukkit.getWorld(config.getString("tp.lobby_world_name", "lobby"));
+      if(lobby == null) {
+        throw new NullPointerException("Lobby World could not be found");
+      }
+      p.teleport(lobby.getSpawnLocation());
+    } else {
+      e.setRespawnLocation(respawn);
+    }
+  }
+
+}

--- a/src/main/java/net/azisaba/afnw/afnwcore2/listeners/player/RespawnNether.java
+++ b/src/main/java/net/azisaba/afnw/afnwcore2/listeners/player/RespawnNether.java
@@ -28,7 +28,7 @@ public record RespawnNether(JavaPlugin plugin) implements Listener {
       if(lobby == null) {
         throw new NullPointerException("Lobby World could not be found");
       }
-      p.teleport(lobby.getSpawnLocation());
+      e.setRespawnLocation(lobby.getSpawnLocation());
     } else {
       e.setRespawnLocation(respawn);
     }


### PR DESCRIPTION
close #44 

サーバークライアントの不具合を暫定的に解決するため、ネザーで死亡した際のリスポーンロケーションを固定する機能を追加